### PR TITLE
removing runtime dependency on jeweler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gem 'rails'
 gem 'rake'
 gem 'rspec', '~> 2.6'
 gem 'rspec-core', '~> 2.6'
+
+
+group :test, :development do
+  gem 'jeweler'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,8 +33,14 @@ GEM
     builder (3.0.0)
     diff-lcs (1.1.2)
     erubis (2.7.0)
+    git (1.2.5)
     hike (1.2.1)
     i18n (0.6.0)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
     json (1.6.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
@@ -95,6 +101,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  jeweler
   pg
   rails
   rake


### PR DESCRIPTION
quick fix that should remove the dependency.  
0.4 didn't depend on jeweler, but 0.5 does
