### PR TITLE
postgres-copy crashes server

### DIFF
--- a/lib/postgres-copy/csv_responder.rb
+++ b/lib/postgres-copy/csv_responder.rb
@@ -1,8 +1,10 @@
-module Responders::CsvResponder
-  def to_csv
-    controller.response_body = Enumerator.new do |y|
-      controller.send(:end_of_association_chain).pg_copy_to do |line|
-        y << line
+module Responders
+  module CsvResponder
+    def to_csv
+      controller.response_body = Enumerator.new do |y|
+        controller.send(:end_of_association_chain).pg_copy_to do |line|
+          y << line
+        end
       end
     end
   end


### PR DESCRIPTION
Added Responders module as seprarate.

May be it was a ruby-193-p125-perf "feature"?

But, without last commit, I have this error stack:

/home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/postgres-copy-0.5.5/lib/postgres-copy/csv_responder.rb:1:in `<top (required)>': uninitialized constant Responders (NameError)
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/postgres-copy-0.5.5/lib/postgres-copy.rb:13:in`block (2 levels) in class:PostgresCopy'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/activesupport-3.2.11/lib/active_support/lazy_load_hooks.rb:36:in `instance_eval'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/activesupport-3.2.11/lib/active_support/lazy_load_hooks.rb:36:in`execute_hook'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/activesupport-3.2.11/lib/active_support/lazy_load_hooks.rb:26:in `block in on_load'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/activesupport-3.2.11/lib/active_support/lazy_load_hooks.rb:25:in`each'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/activesupport-3.2.11/lib/active_support/lazy_load_hooks.rb:25:in `on_load'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/postgres-copy-0.5.5/lib/postgres-copy.rb:12:in`block in class:PostgresCopy'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/initializable.rb:30:in `instance_exec'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/initializable.rb:30:in`run'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/initializable.rb:54:in`each'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/initializable.rb:54:in `run_initializers'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/application.rb:136:in`initialize!'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/railtie/configurable.rb:30:in `method_missing'
    from /home/umka/git/nipplesystem/nippelapp/config/environment.rb:21:in`<top (required)>'
    from /home/umka/git/nipplesystem/nippelapp/config.ru:3:in `block in <main>'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/builder.rb:51:in`instance_eval'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/builder.rb:51:in `initialize'
    from /home/umka/git/nipplesystem/nippelapp/config.ru:in`new'
    from /home/umka/git/nipplesystem/nippelapp/config.ru:in `<main>'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/builder.rb:40:in`eval'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/builder.rb:40:in `parse_file'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/server.rb:200:in`app'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/commands/server.rb:46:in `app'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/server.rb:304:in`wrapped_app'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/rack-1.4.4/lib/rack/server.rb:254:in `start'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/commands/server.rb:70:in`start'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/commands.rb:55:in `block in <top (required)>'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/commands.rb:50:in`tap'
    from /home/umka/.rvm/gems/ruby-1.9.3-p125-perf@nippelapp/gems/railties-3.2.11/lib/rails/commands.rb:50:in `<top (required)>'
    from script/rails:6:in`require'
    from script/rails:6:in `<main>'
