### PR TITLE
performance improvement pg_copy_to_string - change the way concat string

### DIFF
--- a/lib/postgres-copy/active_record.rb
+++ b/lib/postgres-copy/active_record.rb
@@ -24,7 +24,7 @@ module ActiveRecord
     # Copy all data to a single string
     def self.pg_copy_to_string options = {}
       data = ''
-      self.pg_copy_to(nil, options){|l| data += l }
+      self.pg_copy_to(nil, options){|l| data << l }
       if options[:format] == :binary
         data.force_encoding("ASCII-8BIT")
       end


### PR DESCRIPTION
``` ruby

require 'benchmark'

Benchmark.bm do |b| 
  b.report('+=') do
    data = ''
    line = 'hello word'

    100_000.times { data += line}
  end

  b.report('<<') do
    data = ''
    line = 'hello word'

    100_000.times { data << line}
  end

end
```

```
       user     system      total        real
+=  8.750000  13.420000  22.170000 ( 22.236511)
<<  0.010000   0.000000   0.010000 (  0.014012)
```
