### PR TITLE
using copy_data which is preferred by pg gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.23)
     multi_json (1.7.3)
-    pg (0.15.1)
+    pg (0.17.1)
     polyglot (0.3.3)
     rack (1.4.5)
     rack-cache (1.2)


### PR DESCRIPTION
Thanks for the new branch!

Pg gem recommends the use of copy_data in newer versions, because it better handles closing the operation.  

https://bitbucket.org/ged/ruby-pg/src/30da9c169efc3985ad0464936483c229faba0e33/lib/pg/connection.rb?at=v0.17.0#cl-97
