### PR TITLE
Removing the date from the gemspec file.

### DIFF
--- a/postgres-copy.gemspec
+++ b/postgres-copy.gemspec
@@ -4,23 +4,21 @@ $:.unshift lib unless $:.include?(lib)
 
 
 Gem::Specification.new do |s|
-  s.name = "postgres-copy"
-  s.version = "0.9.2"
-
-  s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version     = ">= 1.9.3"
-  s.authors = ["Diogo Biazus"]
-  s.date = "2013-01-31"
-  s.description = "Now you can use the super fast COPY for import/export data directly from your AR models."
-  s.email = "diogob@gmail.com"
-  git_files            = `git ls-files`.split("\n") rescue ''
-  s.files              = git_files
-  s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables        = []
-  s.require_paths      = %w(lib)
-  s.homepage = "http://github.com/diogob/postgres-copy"
-  s.require_paths = ["lib"]
-  s.summary = "Put COPY command functionality in ActiveRecord's model class"
+  s.name                  = "postgres-copy"
+  s.version               = "0.9.2"
+  s.platform              = Gem::Platform::RUBY
+  s.required_ruby_version = ">= 1.9.3"
+  s.authors               = ["Diogo Biazus"]
+  s.description           = "Now you can use the super fast COPY for import/export data directly from your AR models."
+  s.email                 = "diogob@gmail.com"
+  git_files               = `git ls-files`.split("\n") rescue ''
+  s.files                 = git_files
+  s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables           = []
+  s.require_paths         = %w(lib)
+  s.homepage              = "http://github.com/diogob/postgres-copy"
+  s.require_paths         = ["lib"]
+  s.summary               = "Put COPY command functionality in ActiveRecord's model class"
 
   s.add_dependency "pg", ">= 0.17"
   s.add_dependency "activerecord", '>= 4.0'


### PR DESCRIPTION
I originally thought this Gem hadn't been updated since 2013, because that's what is being reported on rubygems.org (https://rubygems.org/gems/postgres-copy). I wanted to remove the hard-coded date from the gemspec file so that the next time it's deployed the date will show up as being recent.

Other than that I just aligned the code.... sorry for being anal about that :)