### PR TITLE
skip over all-nil records like we do for blank lines

### DIFF
--- a/lib/postgres-copy/acts_as_copy_target.rb
+++ b/lib/postgres-copy/acts_as_copy_target.rb
@@ -85,6 +85,7 @@ module PostgresCopy
               if block_given?
                 row = line.strip.split(options[:delimiter],-1)
                 yield(row)
+                next if row.all?{|f| f.nil? }
                 line = row.join(options[:delimiter]) + "\n"
               end
               connection.raw_connection.put_copy_data line

--- a/spec/copy_from_spec.rb
+++ b/spec/copy_from_spec.rb
@@ -79,6 +79,15 @@ describe "COPY FROM" do
     TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => 'test data 1'}]
   end
 
+  it "should ignore all-nil rows" do
+    lambda do
+      TestModel.copy_from(File.open(File.expand_path('spec/fixtures/tab_with_error.csv'), 'r'), :delimiter => "\t") do |row|
+        0.upto(row.length) {|idx| row[idx] = nil}
+      end
+    end.should_not raise_error
+    TestModel.order(:id).map{|r| r.attributes}.should == []
+  end
+
   #we should implement this later
   #it "should raise error in malformed files" do
     #lambda do


### PR DESCRIPTION
This allows the block given to `copy_from` to `nil'`ify the row, and have postgres-copy skip it.  Since we auto-skip blank lines anyway, I'm guessing for most users skipping all-empty records is a benefit.  Maybe it should be a flag?

I considered checking whether the block returned `nil`/`false`, but I didn't want to change the current behavior too much.