### PR TITLE
Support NULL option parmeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ The above extample will always change the value of the first column to "fixed st
 For each iteration of the block row receives an array with the same order as the columns in the CSV file.
 
 
+To specify NULL value you can pass the null option parameter.
+
+```ruby
+User.copy_from "/tmp/users.csv", :null => 'null'
+```
+
+
 To copy a binary formatted data file or IO object you can specify the format as binary
 
 ```ruby

--- a/lib/postgres-copy/acts_as_copy_target.rb
+++ b/lib/postgres-copy/acts_as_copy_target.rb
@@ -48,7 +48,8 @@ module PostgresCopy
                            "BINARY"
                          else
                            quote = options[:quote] == "'" ? "''" : options[:quote]
-                           "DELIMITER '#{options[:delimiter]}' QUOTE '#{quote}' CSV"
+                           null = options.key?(:null) ? "NULL '#{options[:null]}'" : ''
+                           "DELIMITER '#{options[:delimiter]}' QUOTE '#{quote}' #{null} CSV"
                          end
         io = path_or_io.instance_of?(String) ? File.open(path_or_io, 'r') : path_or_io
 

--- a/spec/copy_from_spec.rb
+++ b/spec/copy_from_spec.rb
@@ -129,4 +129,13 @@ describe "COPY FROM" do
     TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => 'test, again'}]
   end
 
+  it "should import with custom null expression from path" do
+    TestModel.copy_from File.expand_path('spec/fixtures/special_null_with_header.csv'), :null => 'NULL'
+    TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => nil}]
+  end
+
+  it "should import with custom null expression from IO" do
+    TestModel.copy_from File.open(File.expand_path('spec/fixtures/special_null_with_header.csv'), 'r'), :null => 'NULL'
+    TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => nil}]
+  end
 end

--- a/spec/fixtures/special_null_with_header.csv
+++ b/spec/fixtures/special_null_with_header.csv
@@ -1,0 +1,2 @@
+id,data
+1,NULL


### PR DESCRIPTION
I think that the NULL option parameter is useful for using COPY FROM command.
So add an option to `copy_from` method for it.