### PR TITLE
Ensure valid row values when fields have commas and block is given

### DIFF
--- a/lib/postgres-copy/acts_as_copy_target.rb
+++ b/lib/postgres-copy/acts_as_copy_target.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module PostgresCopy
   module ActsAsCopyTarget
     extend ActiveSupport::Concern
@@ -84,10 +86,10 @@ module PostgresCopy
             while line = io.gets do
               next if line.strip.size == 0
               if block_given?
-                row = line.strip.split(options[:delimiter],-1)
+                row = CSV.parse_line(line.strip, {:col_sep => options[:delimiter]})
                 yield(row)
                 next if row.all?{|f| f.nil? }
-                line = row.join(options[:delimiter]) + "\n"
+                line = CSV.generate_line(row, {:col_sep => options[:delimiter]})
               end
               connection.raw_connection.put_copy_data line
             end

--- a/spec/copy_from_spec.rb
+++ b/spec/copy_from_spec.rb
@@ -130,11 +130,13 @@ describe "COPY FROM" do
   end
 
   it "should import lines with commas inside fields with block given" do
-    TestModel.copy_from(File.open(File.expand_path('spec/fixtures/comma_inside_field.csv'), 'r')) do |row|
-      # since our CSV line look like this: {1,"test, again"} we expect only two elements withing row
-      row.size.should == 2
-      row[0].should == '1'
-      row[1].should == 'test, again'
+    File.open(File.expand_path('spec/fixtures/comma_inside_field.csv'), 'r') do |file|
+      TestModel.copy_from(file) do |row|
+        # since our CSV line look like this: {1,"test, again"} we expect only two elements withing row
+        row.size.should == 2
+        row[0].should == '1'
+        row[1].should == 'test, again'
+      end
     end
     TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => 'test, again'}]
   end

--- a/spec/copy_from_spec.rb
+++ b/spec/copy_from_spec.rb
@@ -129,6 +129,16 @@ describe "COPY FROM" do
     TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => 'test, again'}]
   end
 
+  it "should import lines with commas inside fields with block given" do
+    TestModel.copy_from(File.open(File.expand_path('spec/fixtures/comma_inside_field.csv'), 'r')) do |row|
+      # since our CSV line look like this: {1,"test, again"} we expect only two elements withing row
+      row.size.should == 2
+      row[0].should == '1'
+      row[1].should == 'test, again'
+    end
+    TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => 'test, again'}]
+  end
+
   it "should import with custom null expression from path" do
     TestModel.copy_from File.expand_path('spec/fixtures/special_null_with_header.csv'), :null => 'NULL'
     TestModel.order(:id).map{|r| r.attributes}.should == [{'id' => 1, 'data' => nil}]


### PR DESCRIPTION
Hey @diogob,

I've noticed and issue while using `postgres-copy`.

When there are commas inside fields and block is given there is a problem with `row` values.
Line is split by delimiter, regardless of CSV format, and when delimiter is a comma, `row` has more values than there are columns.

I've added a test that demonstrates the issue.

To fix it, I've simply added CSV lib to parse the line and avoid splitting just by delimiter. Line is split with regards to CSV format.

When `yield` finishes, line is again generated by CSV lib `generate_line` to ensure the line is a valid CSV line.

Please let me know what you think!