### PR TITLE
Fix for ActiveRecord 5.1, break backwards compat

### DIFF
--- a/lib/postgres-copy/acts_as_copy_target.rb
+++ b/lib/postgres-copy/acts_as_copy_target.rb
@@ -19,7 +19,7 @@ module PostgresCopy
 
         if path
           raise "You have to choose between exporting to a file or receiving the lines inside a block" if block_given?
-          connection.execute "COPY (#{self.all.to_sql}) TO #{sanitize(path)} WITH #{options_string}"
+          connection.execute "COPY (#{self.all.to_sql}) TO '#{sanitize_sql(path)}' WITH #{options_string}"
         else
           connection.raw_connection.copy_data "COPY (#{self.all.to_sql}) TO STDOUT WITH #{options_string}" do
             while line = connection.raw_connection.get_copy_data do

--- a/postgres-copy.gemspec
+++ b/postgres-copy.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name                  = "postgres-copy"
-  s.version               = "1.2.0"
+  s.version               = "1.3.0"
   s.platform              = Gem::Platform::RUBY
   s.required_ruby_version = ">= 1.9.3"
   s.authors               = ["Diogo Biazus"]
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.summary               = "Put COPY command functionality in ActiveRecord's model class"
 
   s.add_dependency "pg", ">= 0.17"
-  s.add_dependency "activerecord", '>= 4.0', '< 5.1'
+  s.add_dependency "activerecord", '>= 5.1'
   s.add_dependency "responders"
   s.add_development_dependency "bundler"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
Should update docs with a table of versions and ActiveRecord compatibility