### PR TITLE
feat: Add encoding option for copy_to method

### DIFF
--- a/lib/postgres-copy/acts_as_copy_target.rb
+++ b/lib/postgres-copy/acts_as_copy_target.rb
@@ -18,11 +18,11 @@ module PostgresCopy
     module CopyMethods
       # Copy data to a file passed as a string (the file path) or to lines that are passed to a block
       def copy_to path = nil, options = {}
-        options = { delimiter: ",", format: :csv, header: true }.merge(options)
+        options = { delimiter: ",", format: :csv, header: true, encoding: "UTF8" }.merge(options)
         options_string = if options[:format] == :binary
                            "BINARY"
                          else
-                           "DELIMITER '#{options[:delimiter]}' CSV #{options[:header] ? 'HEADER' : ''}"
+                           "DELIMITER '#{options[:delimiter]}' CSV #{options[:header] ? 'HEADER' : ''} ENCODING '#{options[:encoding]}'"
                          end
         options_query = options.delete(:query) || self.all.to_sql
 

--- a/spec/copy_to_spec.rb
+++ b/spec/copy_to_spec.rb
@@ -80,23 +80,27 @@ describe "COPY TO" do
 
     context "when ascii encoding is given as argument" do
       it "saves file with ascii encoding" do
-        file_path = '/tmp/encoding.csv'
+        file_path = File.join(File.dirname(__FILE__), 'fixtures/encoding.csv')
 
         TestModel.copy_to file_path, encoding: "SQL_ASCII", query: 'SELECT count(*) as "Total" FROM test_models'
         encoding = `file --mime #{file_path}`.strip.split('charset=').last
 
         expect(encoding).to eq("us-ascii")
+
+        File.write(file_path, "")
       end
     end
 
     context "when no encoding argument is given" do
       it "defaults to utf8 encoding" do
-        file_path = '/tmp/encoding.csv'
+        file_path = File.join(File.dirname(__FILE__), 'fixtures/encoding.csv')
 
         TestModel.copy_to file_path, query: 'SELECT count(*) as "全部的" FROM test_models'
         encoding = `file --mime #{file_path}`.strip.split('charset=').last
 
         expect(encoding).to eq("utf-8")
+
+        File.write(file_path, "")
       end
     end
   end

--- a/spec/copy_to_spec.rb
+++ b/spec/copy_to_spec.rb
@@ -77,5 +77,27 @@ describe "COPY TO" do
         break
       end
     end
+
+    context "when ascii encoding is given as argument" do
+      it "saves file with ascii encoding" do
+        file_path = '/tmp/encoding.csv'
+
+        TestModel.copy_to file_path, encoding: "SQL_ASCII", query: 'SELECT count(*) as "Total" FROM test_models'
+        encoding = `file --mime #{file_path}`.strip.split('charset=').last
+
+        expect(encoding).to eq("us-ascii")
+      end
+    end
+
+    context "when no encoding argument is given" do
+      it "defaults to utf8 encoding" do
+        file_path = '/tmp/encoding.csv'
+
+        TestModel.copy_to file_path, query: 'SELECT count(*) as "全部的" FROM test_models'
+        encoding = `file --mime #{file_path}`.strip.split('charset=').last
+
+        expect(encoding).to eq("utf-8")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR aims to add an encoding option for `copy_to` methods. If none is specified, it defaults to _UTF8_.
