### PR TITLE
Ruby 3.4 dependency gemspec change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     postgres-copy (1.7.1)
       activerecord (>= 5.1)
+      csv
       pg (>= 0.17)
 
 GEM
@@ -19,6 +20,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     concurrent-ruby (1.1.10)
+    csv (3.3.0)
     diff-lcs (1.5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)

--- a/postgres-copy.gemspec
+++ b/postgres-copy.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "pg", ">= 0.17"
   s.add_dependency "activerecord", '>= 5.1'
+  s.add_dependency "csv"
   s.add_development_dependency "bundler"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
```
csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of postgres-copy-1.7.1 to add csv into its gemspec.
```